### PR TITLE
Log more service events and remove project event logging

### DIFF
--- a/project/listener.go
+++ b/project/listener.go
@@ -8,22 +8,24 @@ import (
 
 var (
 	infoEvents = map[EventType]bool{
-		EventProjectDeleteDone:   true,
-		EventProjectDeleteStart:  true,
-		EventProjectDownDone:     true,
-		EventProjectDownStart:    true,
-		EventProjectRestartDone:  true,
-		EventProjectRestartStart: true,
-		EventProjectUpDone:       true,
-		EventProjectUpStart:      true,
 		EventServiceDeleteStart:  true,
 		EventServiceDelete:       true,
 		EventServiceDownStart:    true,
 		EventServiceDown:         true,
+		EventServiceStopStart:    true,
+		EventServiceStop:         true,
+		EventServiceKillStart:    true,
+		EventServiceKill:         true,
+		EventServiceStartStart:   true,
+		EventServiceStart:        true,
 		EventServiceRestartStart: true,
 		EventServiceRestart:      true,
 		EventServiceUpStart:      true,
 		EventServiceUp:           true,
+		EventServicePauseStart:   true,
+		EventServicePause:        true,
+		EventServiceUnpauseStart: true,
+		EventServiceUnpause:      true,
 	}
 )
 

--- a/project/types.go
+++ b/project/types.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+
 	"github.com/docker/libcompose/config"
 )
 
@@ -126,6 +127,14 @@ func (e EventType) String() string {
 		m = "Executing"
 	case EventServiceRun:
 		m = "Executed"
+	case EventServicePauseStart:
+		m = "Pausing"
+	case EventServicePause:
+		m = "Paused"
+	case EventServiceUnpauseStart:
+		m = "Unpausing"
+	case EventServiceUnpause:
+		m = "Unpaused"
 
 	case EventProjectDownStart:
 		m = "Stopping project"
@@ -167,6 +176,14 @@ func (e EventType) String() string {
 		m = "Building project"
 	case EventProjectBuildDone:
 		m = "Project built"
+	case EventProjectPauseStart:
+		m = "Pausing project"
+	case EventProjectPauseDone:
+		m = "Project paused"
+	case EventProjectUnpauseStart:
+		m = "Unpausing project"
+	case EventProjectUnpauseDone:
+		m = "Project unpaused"
 	}
 
 	if m == "" {


### PR DESCRIPTION
Enable logging in more commands such as create and stop, which don't currently have logging enabled. Remove project logging to behave more like Docker Compose and prevent confusion around project/stack deletion.

rancher/rancher#4887
rancher/rancher#4933
rancher/rancher#4787
